### PR TITLE
Fixes #2 - Changed 'tcp-request content accept' to 'tcp-request content reject'

### DIFF
--- a/haproxy/downstream.go
+++ b/haproxy/downstream.go
@@ -82,8 +82,8 @@ func (h *HAProxy) handleDownstream(tx *tnx, ds consul.Downstream) error {
 		}
 
 		err = tx.CreateTCPRequestRule("frontend", feName, models.TCPRequestRule{
-			Action:   models.TCPRequestRuleActionAccept,
-			Cond:     models.TCPRequestRuleCondIf,
+			Action:   models.TCPRequestRuleActionReject,
+			Cond:     models.TCPRequestRuleCondUnless,
 			CondTest: "{ var(sess.connect.auth) -m int eq 1 }",
 			Type:     models.TCPRequestRuleTypeContent,
 			ID:       &filterID,


### PR DESCRIPTION
Changed 'downstream' configuration so that when Intentations are enabled, a 'tcp-request content reject' is added instead of a 'tcp-request content accept'. That way, messages are rejected unless the Intention approves them. 

Currently, as-is, all messages are accepted regardless of the Intention rules. 

I have tested this by adding 'accept' and 'deny' Intentions and making a call from one proxy to an upstream. I also tested if this works when the ACL default_policy is either 'allow' or 'deny'.